### PR TITLE
enable multi worker support

### DIFF
--- a/lib/fluent/plugin/in_rabbitmq.rb
+++ b/lib/fluent/plugin/in_rabbitmq.rb
@@ -120,6 +120,10 @@ module Fluent::Plugin
       end
     end
     
+    def multi_workers_ready?
+      true
+    end
+
     def shutdown
       @bunny.close
       super

--- a/lib/fluent/plugin/out_rabbitmq.rb
+++ b/lib/fluent/plugin/out_rabbitmq.rb
@@ -141,6 +141,10 @@ module Fluent::Plugin
       end
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     private
 
     def format(tag, time, record)


### PR DESCRIPTION
Hi!

According to Bunny docs http://rubybunny.info/articles/concurrency.html it should be ok to enable multi worker support, as start() is called per worker, therefor also bunny Channels are separate by worker.

Or am i missing something here?
Best,
Erich