### PR TITLE
Convert timestamps to `Fluent::EventTime` to prevent type errors

### DIFF
--- a/lib/fluent/plugin/in_rabbitmq.rb
+++ b/lib/fluent/plugin/in_rabbitmq.rb
@@ -114,7 +114,11 @@ module Fluent::Plugin
       end
       queue.subscribe do |delivery_info, properties, payload|
         @parser.parse(payload) do |time, record|
-          time = properties[:timestamp] || time
+          time = if properties[:timestamp]
+                    Fluent::EventTime.from_time(properties[:timestamp])
+                 else
+                    time
+                 end
           router.emit(@tag, time, record)
         end
       end

--- a/test/plugin/test_in_rabbitmq.rb
+++ b/test/plugin/test_in_rabbitmq.rb
@@ -113,6 +113,21 @@ class RabbitMQInputTest < Test::Unit::TestCase
     end
   end
 
+  def test_emit_with_timestamp
+    d = create_driver
+
+    expect_time = Fluent::EventTime.parse("2018-08-15 13:14:15 UTC")
+    expect_hash = {"foo" => "bar"}
+    d.run(expect_emits: 1) do
+      @fanout_exchange.publish(expect_hash.to_json, timestamp: expect_time.to_i)
+    end
+
+    d.events.each do |event|
+      assert_equal expect_time, event[1]
+      assert_equal expect_hash, event[2]
+    end
+  end
+
   def test_emit_direct
     conf = CONFIG.clone.gsub(/queue\stest_in_fanout/, "queue test_in_direct")
     d = create_driver(conf)


### PR DESCRIPTION
This patch fixes the issue reported by #6.

### Problem

What used to happen is that RabbitMQInput simply emitted the value of
properties['timestamp'], whose type is `Time` not `EventTime`. Since
input plugins are supposed to emit timestamps in `EventTime`, this was
causing unexpected exceptions (type errors) in the down stream.

### Solution

This patch fixes the issue by coercing the type of timestamps properly
before emitting events.
