### PR TITLE
Adding option to create exchange and bind it to another one and adding ttl param to queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .gem
+.idea

--- a/README.md
+++ b/README.md
@@ -46,10 +46,16 @@ fluentd >= 0.14.0
 |durable|true|false|set durable flag of the queue|
 |exclusive|true|false|set exclusive flag of the queue|
 |auto_delete|true|false|set auto_delete flag of the queue|
+|ttl|60000|nil|queue ttl in ms|
 |prefetch_count|10|nil||
 |consumer_pool_size|5|nil||
 |include_headers|true|false|include headers in events|
 |headers_key|string|header|key name of headers|
+|create_exchange|true|false|create exchange or not|
+|exchange_to_bind|string|nil|exchange to bind created exchange|
+|exchange_type|direct|topic|type of created exchange|
+|exchange_routing_key|hoge|nil|created exchange routing key|
+|exchange_durable|true|false|durability of create exchange|
 
 ### Output
 


### PR DESCRIPTION
Our rabbit can move and drop all queues and exchanges. We want fluentd to be able to automatically recreate relevant exchanges on "IN" plugin.

The way we work : we have one fanout exchange that all messages are coming in, then we create topic exchange with relevant routing key and bind it to global queue. Such way every consumer is on charge on it's own exchange.