### PR TITLE
Add delivery_info data to record (with option)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /spec/reports/
 /tmp/
 .gem
+*.gem
 .idea

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |test|
-  test.libs << "lib" << "test"
+  test.libs << "test"
   test.pattern = "test/**/test_*.rb"
   test.verbose = false
   test.warning = false

--- a/fluent-plugin-rabbitmq.gemspec
+++ b/fluent-plugin-rabbitmq.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-rabbitmq"
-  spec.version       = "0.0.7"
+  spec.version       = "0.0.8"
   spec.authors       = ["NTT Communications"]
   spec.email         = ["masaki.matsushita@ntt.com"]
 

--- a/lib/fluent/plugin/in_rabbitmq.rb
+++ b/lib/fluent/plugin/in_rabbitmq.rb
@@ -68,7 +68,9 @@ module Fluent::Plugin
     config_param :ttl, :integer, default: nil
 
     config_param :include_headers, :bool, default: false
+    config_param :include_delivery_info, :bool, default: false
     config_param :headers_key, :string, default: "headers"
+    config_param :delivery_info_key, :string, default: "delivery_info"
 
     def initialize
       super
@@ -143,6 +145,9 @@ module Fluent::Plugin
                  end
           if @include_headers
             record[@headers_key] = properties.headers
+          end
+          if @include_delivery_info
+            record[@delivery_info_key] = delivery_info
           end
           router.emit(@tag, time, record)
         end


### PR DESCRIPTION
Reproduced the include_header philosophy :

- Add an include_delivery_info (false by default) with delivery_info_key (delivery_info by default)
- Add corresponding unit test to check the option
