### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ fluentd >= 0.14.0
   <parse>
     @type json # or msgpack, ltsv, none
   </parse>
-  <buffer> # to use in buffered mode
-  </buffer>
 </source>
 ```
 
@@ -76,6 +74,8 @@ fluentd >= 0.14.0
   <format>
     @type json # or msgpack, ltsv, none
   </format>
+  <buffer> # to use in buffered mode
+  </buffer>
 </match>
 ```
 


### PR DESCRIPTION
On commit 94c145e the configuration example for the buffered options in the _output_ ended up in the _input_, where it doesn't have any effect.