### PR TITLE
Add support for reading from quorum queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ fluentd >= 0.14.0
 |exchange_durable|true|false|durability of create exchange|
 |manual_ack|true|false|manual ACK|
 |queue_mode|"lazy"|nil|queue mode|
+|queue_type|"quorum"|nil|queue type|
+
 
 ### Output
 

--- a/fluent-plugin-rabbitmq.gemspec
+++ b/fluent-plugin-rabbitmq.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-rabbitmq"
-  spec.version       = "0.1.0"
+  spec.version       = "0.1.1"
   spec.authors       = ["NTT Communications"]
   spec.email         = ["masaki.matsushita@ntt.com"]
 

--- a/lib/fluent/plugin/in_rabbitmq.rb
+++ b/lib/fluent/plugin/in_rabbitmq.rb
@@ -73,6 +73,7 @@ module Fluent::Plugin
     config_param :delivery_info_key, :string, default: "delivery_info"
     config_param :manual_ack, :bool, default: false
     config_param :queue_mode, :string, default: nil
+    config_param :queue_type, :string, default: nil
 
     def initialize
       super
@@ -130,6 +131,7 @@ module Fluent::Plugin
       queue_arguments = {}
       queue_arguments["x-message-ttl"] = @ttl if @ttl
       queue_arguments["x-queue-mode"] = @queue_mode if @queue_mode
+      queue_arguments["x-queue-type"] = @queue_type if @queue_type
       queue = channel.queue(
         @queue,
         durable: @durable,


### PR DESCRIPTION
This PR adds the ability to specify queue type via the flags in the fluentd configuration file.